### PR TITLE
Properly filter voices in ListVoices

### DIFF
--- a/ivona.go
+++ b/ivona.go
@@ -71,7 +71,16 @@ func (client *Ivona) CreateSpeech(options SpeechOptions) (*SpeechResponse, error
 
 // ListVoices retrieves list of voices from the api
 func (client *Ivona) ListVoices(options Voice) (*ListResponse, error) {
-	b, err := json.Marshal(options)
+	voiceOptions := struct {
+		Gender 	 string `json:",omitempty"`
+		Language string `json:",omitempty"`
+		Name 	 string `json:",omitempty"`
+	}{}
+	voiceOptions.Gender = options.Gender
+	voiceOptions.Language = options.Language
+	voiceOptions.Name = options.Name
+
+	b, err := json.Marshal(map[string]interface{}{ "Voice": voiceOptions })
 	if err != nil {
 		return nil, err
 	}

--- a/ivona_test.go
+++ b/ivona_test.go
@@ -1,10 +1,8 @@
-package ivona_test
+package ivona
 
 import (
 	"os"
 	"testing"
-
-	ivona "github.com/jpadilla/ivona-go"
 )
 
 var (
@@ -20,8 +18,8 @@ func init() {
 }
 
 func TestIvona_CreateSpeech(t *testing.T) {
-	client := ivona.New(ivonaAccessKey, ivonaSecretKey)
-	options := ivona.NewSpeechOptions(testText)
+	client := New(ivonaAccessKey, ivonaSecretKey)
+	options := NewSpeechOptions(testText)
 	r, err := client.CreateSpeech(options)
 
 	if err != nil {
@@ -42,9 +40,9 @@ func TestIvona_CreateSpeech(t *testing.T) {
 }
 
 func TestIvona_ListVoices(t *testing.T) {
-	client := ivona.New(ivonaAccessKey, ivonaSecretKey)
+	client := New(ivonaAccessKey, ivonaSecretKey)
 
-	r, err := client.ListVoices(ivona.Voice{})
+	r, err := client.ListVoices(Voice{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/ivona_test.go
+++ b/ivona_test.go
@@ -58,4 +58,16 @@ func TestIvona_ListVoices(t *testing.T) {
 	if r.ContentType != expectedContentType {
 		t.Errorf("ContentType %v does not match", r.ContentType)
 	}
+
+	r, err = client.ListVoices(Voice{ Gender: "Female" })
+	if err != nil {
+		t.Error(err)
+	}
+
+	voicesLength = len(r.Voices)
+	allVoicesLength := expectedVoicesLength
+
+	if voicesLength == allVoicesLength {
+		t.Errorf("Voices length %v is larger than expected", len(r.Voices))
+	}
 }


### PR DESCRIPTION
I've noticed that the `ListVoices` call creates an incorrect request data structure -- the voice attributes should be encapsulated in a higher-level `Voice` object, e.g.:

``` json
{
    "Voice" : {
        "Name" : "string",
        "Language" : "string",
        "Gender" : "string"
    }
}
```

These changes fix the issue.
